### PR TITLE
Add Markdown support plugin for SMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Markdown Support for Simple Machines Forum 2.1
+
+This modification enables Markdown formatting in Simple Machines Forum (SMF) 2.1.4 and higher. It automatically converts Markdown syntax into BBCode when users create new posts and seamlessly parses legacy messages that contain Markdown when they are displayed.
+
+## Features
+
+- Automatic Markdown → BBCode conversion on post submission
+- Runtime conversion for existing Markdown posts to maintain formatting
+- Support for headings, emphasis, lists, blockquotes, code blocks, inline code, links, images, horizontal rules, and strikethrough
+
+## Installation
+
+1. Create a release archive (e.g. `MarkdownSupport-1.0.0.zip`) containing the contents of this repository.
+2. Upload the archive via the SMF Package Manager (`Admin » Package Manager » Download Packages`).
+3. Follow the installation prompts.
+
+## Uninstallation
+
+Uninstall through the Package Manager. All integration hooks and added files are removed automatically.
+
+## Customisation
+
+The Markdown to BBCode conversion is implemented in `Sources/MarkdownSupport/Parser.php`. You can expand or adjust the supported syntax there if needed.

--- a/Sources/MarkdownSupport/Hooks.php
+++ b/Sources/MarkdownSupport/Hooks.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MarkdownSupport;
+
+if (!defined('SMF')) {
+    die('No direct access...');
+}
+
+class Hooks
+{
+    /** @var Parser|null */
+    protected static $parser = null;
+
+    protected static function getParser(): Parser
+    {
+        if (self::$parser === null) {
+            self::$parser = new Parser();
+        }
+
+        return self::$parser;
+    }
+
+    /**
+     * Hook for integrate_preparsecode: converts Markdown to BBCode before saving posts.
+     *
+     * @param string $message
+     */
+    public static function preparseCode(&$message)
+    {
+        if (empty($message) || !is_string($message)) {
+            return;
+        }
+
+        $message = self::getParser()->toBBCode($message);
+    }
+
+    /**
+     * Hook for integrate_preparsebbc: allows rendering Markdown in existing posts.
+     *
+     * @param string $message
+     */
+    public static function preparseBBC(&$message)
+    {
+        if (empty($message) || !is_string($message)) {
+            return;
+        }
+
+        $parser = self::getParser();
+        if ($parser->hasBBCode($message)) {
+            return;
+        }
+
+        $message = $parser->toBBCode($message);
+    }
+}

--- a/Sources/MarkdownSupport/Parser.php
+++ b/Sources/MarkdownSupport/Parser.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace MarkdownSupport;
+
+/**
+ * Lightweight Markdown to BBCode converter tailored for SMF.
+ */
+class Parser
+{
+    /**
+     * Convert Markdown syntax to BBCode.
+     */
+    public function toBBCode(string $text): string
+    {
+        if ($text === '') {
+            return $text;
+        }
+
+        $text = str_replace(["\r\n", "\r"], "\n", $text);
+
+        // Extract fenced code blocks to placeholders to avoid accidental conversion.
+        $codeBlocks = [];
+        $text = preg_replace_callback(
+            '/```(\w+)?\n([\s\S]*?)```/m',
+            function (array $matches) use (&$codeBlocks) {
+                $index = count($codeBlocks);
+                $language = !empty($matches[1]) ? '=' . $matches[1] : '';
+                $code = rtrim($matches[2], "\n");
+                $codeBlocks[$index] = "[code{$language}]{$code}[/code]";
+                return "[[MD_CODE_BLOCK_{$index}]]";
+            },
+            $text
+        );
+
+        // Horizontal rules
+        $text = preg_replace('/^\s*(\*\s?){3,}$|^\s*(-\s?){3,}$|^\s*(_\s?){3,}$/m', "\n[hr]\n", $text);
+
+        // Headings
+        $text = preg_replace_callback(
+            '/^(#{1,6})\s+(.+)$/m',
+            function (array $matches) {
+                $level = strlen($matches[1]);
+                $content = trim($matches[2]);
+                $sizes = [1 => '24pt', 2 => '18pt', 3 => '16pt', 4 => '14pt', 5 => '12pt', 6 => '11pt'];
+                $size = $sizes[$level] ?? '12pt';
+                return "[size={$size}][b]{$content}[/b][/size]";
+            },
+            $text
+        );
+
+        // Blockquotes
+        $text = preg_replace_callback(
+            '/(^>.*(?:\n>.*)*)/m',
+            function (array $matches) {
+                $content = preg_replace('/^>\s?/m', '', $matches[1]);
+                $content = trim($content);
+                return "[quote]{$content}[/quote]";
+            },
+            $text
+        );
+
+        // Ordered lists
+        $text = preg_replace_callback(
+            '/(^\s*\d+\.\s+.*(?:\n\s*\d+\.\s+.*)*)/m',
+            function (array $matches) {
+                $items = preg_split('/\n/', trim($matches[1]));
+                $buffer = "[list type=decimal]\n";
+                foreach ($items as $item) {
+                    $buffer .= '[*]' . preg_replace('/^\s*\d+\.\s+/', '', $item) . "\n";
+                }
+                $buffer .= '[/list]';
+                return $buffer;
+            },
+            $text
+        );
+
+        // Unordered lists
+        $text = preg_replace_callback(
+            '/(^\s*[-+*]\s+.*(?:\n\s*[-+*]\s+.*)*)/m',
+            function (array $matches) {
+                $items = preg_split('/\n/', trim($matches[1]));
+                $buffer = "[list]\n";
+                foreach ($items as $item) {
+                    $buffer .= '[*]' . preg_replace('/^\s*[-+*]\s+/', '', $item) . "\n";
+                }
+                $buffer .= '[/list]';
+                return $buffer;
+            },
+            $text
+        );
+
+        // Images ![alt](src)
+        $text = preg_replace_callback(
+            '/!\[(.*?)\]\(([^\s\)]+)(?:\s+"(.*?)")?\)/',
+            function (array $matches) {
+                $alt = trim($matches[1]);
+                $url = trim($matches[2]);
+                $bbcode = '[img]' . $url . '[/img]';
+                if ($alt !== '') {
+                    $bbcode = '[img alt=' . $this->escapeAttribute($alt) . ']' . $url . '[/img]';
+                }
+                return $bbcode;
+            },
+            $text
+        );
+
+        // Links [text](url)
+        $text = preg_replace_callback(
+            '/\[(.*?)\]\(([^\s\)]+)(?:\s+"(.*?)")?\)/',
+            function (array $matches) {
+                $label = trim($matches[1]);
+                $url = trim($matches[2]);
+                return '[url=' . $url . ']' . ($label !== '' ? $label : $url) . '[/url]';
+            },
+            $text
+        );
+
+        // Bold and italic emphasis
+        $text = preg_replace('/\*\*(.+?)\*\*/s', '[b]$1[/b]', $text);
+        $text = preg_replace('/__(.+?)__/s', '[b]$1[/b]', $text);
+
+        $text = preg_replace('/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/s', '[i]$1[/i]', $text);
+        $text = preg_replace('/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/s', '[i]$1[/i]', $text);
+
+        // Strikethrough
+        $text = preg_replace('/~~(.+?)~~/s', '[s]$1[/s]', $text);
+
+        // Inline code
+        $text = preg_replace_callback(
+            '/`([^`]+)`/',
+            function (array $matches) {
+                return '[tt]' . $matches[1] . '[/tt]';
+            },
+            $text
+        );
+
+        // Restore fenced code blocks
+        if (!empty($codeBlocks)) {
+            foreach ($codeBlocks as $index => $replacement) {
+                $text = str_replace("[[MD_CODE_BLOCK_{$index}]]", $replacement, $text);
+            }
+        }
+
+        // Convert double newlines to paragraphs (handled by SMF automatically) - no change required.
+        return $text;
+    }
+
+    /**
+     * Check if the message likely already contains BBCode markup.
+     */
+    public function hasBBCode(string $text): bool
+    {
+        return (bool) preg_match('/\[(?:b|i|u|s|code|quote|list|url|img|table|size|color|font|tt|pre)/i', $text);
+    }
+
+    private function escapeAttribute(string $value): string
+    {
+        return strtr($value, ['[' => '', ']' => '', '=' => '-', '"' => '', "'" => '']);
+    }
+}

--- a/package-info.xml
+++ b/package-info.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE package-info SYSTEM "http://www.simplemachines.org/xml/package-info"> 
+<package-info xmlns="http://www.simplemachines.org/xml/package-info" version="1.0">
+    <id>markdownsupport:smf</id>
+    <name>Markdown Support</name>
+    <type>modification</type>
+    <version>1.0.0</version>
+    <install for="2.1.4-2.1.*">
+        <readme>README.md</readme>
+        <file name="Sources/MarkdownSupport/Parser.php" destination="$sourcedir/MarkdownSupport/Parser.php" />
+        <file name="Sources/MarkdownSupport/Hooks.php" destination="$sourcedir/MarkdownSupport/Hooks.php" />
+        <hook hook="integrate_preparsecode" function="MarkdownSupport\\Hooks::preparseCode" file="$sourcedir/MarkdownSupport/Hooks.php" />
+        <hook hook="integrate_preparsebbc" function="MarkdownSupport\\Hooks::preparseBBC" file="$sourcedir/MarkdownSupport/Hooks.php" />
+    </install>
+    <uninstall for="2.1.4-2.1.*">
+        <remove file="$sourcedir/MarkdownSupport/Parser.php" />
+        <remove file="$sourcedir/MarkdownSupport/Hooks.php" />
+        <hook hook="integrate_preparsecode" function="MarkdownSupport\\Hooks::preparseCode" file="$sourcedir/MarkdownSupport/Hooks.php" reverse="true" />
+        <hook hook="integrate_preparsebbc" function="MarkdownSupport\\Hooks::preparseBBC" file="$sourcedir/MarkdownSupport/Hooks.php" reverse="true" />
+    </uninstall>
+</package-info>


### PR DESCRIPTION
## Summary
- add a lightweight Markdown to BBCode parser covering common syntax such as headings, emphasis, lists, quotes, code, links, and images
- register SMF integration hooks so Markdown is converted on post submission and at render time for existing content
- provide packaging metadata and documentation for installing the modification on SMF 2.1.4+

## Testing
- php -l Sources/MarkdownSupport/Parser.php
- php -l Sources/MarkdownSupport/Hooks.php

------
https://chatgpt.com/codex/tasks/task_e_68cdf4357f488326ac3fb95bf0dbe645